### PR TITLE
Prompt the user for the token

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -1,10 +1,11 @@
 require('colors');
 
 const configManager = require('../util/configManager');
+const prompts = require('prompts');
 
 let commands = ['token'];
 
-module.exports = function(args) {
+module.exports = async function(args) {
   // Help text how to use the config command
   let usage = [
     'Usage:',
@@ -12,6 +13,13 @@ module.exports = function(args) {
     '',
     'Valid commands are: ' + commands.join(' ').cyan
   ];
+
+  // Prompts
+  let tokenPrompt = [{
+    type: 'text',
+    name: 'token',
+    message: 'Enter transifex token: '
+  }];
 
   // If command is missing
   if (commands.indexOf(args['_'][1]) < 0) {
@@ -22,14 +30,16 @@ module.exports = function(args) {
   }
 
   if (args['_'][1] === 'token') {
+    let token;
+
     // If no token is submitted
     if (typeof args['_'][2] === 'undefined') {
-      process.stdout.write('\nPlease enter a token\n');
-      process.stdout.write('Usage: ' + 'i18ntool config token <token>'.cyan + '\n\n');
-      return;
+      token  = (await prompts(tokenPrompt)).token;
+    } else {
+      token = args['_'][2];
     }
 
     // Save token
-    configManager(args['_'][1], args['_'][2]);
+    configManager(args['_'][1], token);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transifex-i18ntool",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A tool to manage xlf translation files on transifex.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
If the user wanted to save the token to the config by running `i18ntool config token` then he was forced to paste the token right behind the command on the cli. 
I changed the behavior to prompt the user if the user does not enter the token directly behind the command. 